### PR TITLE
Allow for custom components

### DIFF
--- a/src/QueryBuilderRule.vue
+++ b/src/QueryBuilderRule.vue
@@ -16,6 +16,10 @@
       <input :class="{ 'form-control': styled }" v-if="rule.inputType === 'text'" type="text" v-model="query.value" :placeholder="labels.textInputPlaceholder"></input>
       <input :class="{ 'form-control': styled }" v-if="rule.inputType === 'number'" type="number" v-model="query.value"></input>
 
+      <template v-if="isCustomComponent">
+        <Custom v-model="query.value"></Custom>
+      </template>
+
       <div class="checkbox" v-if="rule.inputType === 'checkbox'">
         <label v-for="choice in rule.choices">
           <input type="checkbox" :value="choice.value" v-model="query.value"> {{ choice.label }}
@@ -39,6 +43,12 @@ export default {
 
   props: ['query', 'index', 'rule', 'styled', 'labels'],
 
+  created () {
+    if (typeof this.rule.type === 'object') {
+      this.$options.components['Custom'] = this.rule.type;
+    }
+  },
+
   methods: {
     remove: function() {
       this.$emit('child-deletion-requested', this.index);
@@ -48,6 +58,10 @@ export default {
   computed: {
     isMultipleChoice () {
       return this.rule.inputType === 'radio' || this.rule.inputType === 'checkbox';
+    },
+
+    isCustomComponent () {
+      return typeof this.rule.type === 'object';
     }
   },
 


### PR DESCRIPTION
A simple change to allow for custom components which provides the user with ultimate flexibility.

The component should implement the "v-model" interface. 

Example:

```
{
	type: {
		props: ['value'],
		render (h) {
			return <MyTaggingComponent onChange={value => this.$emit('input', value)}></MyTaggingComponent>;
		}
	},
	id: 'tags',
	label: 'Tags',
	operators: ['Has Tag']
}
```