### PR TITLE
Deepclone default value for custom-components

### DIFF
--- a/src/components/QueryBuilderRule.vue
+++ b/src/components/QueryBuilderRule.vue
@@ -119,7 +119,10 @@ export default {
           updated_query.value = this.rule.choices[0].value;
       }
       if (this.rule.type === 'custom-component') {
-          updated_query.value = this.rule.default || null;
+        updated_query.value = null;
+        if(typeof this.rule.default !== 'undefined') {
+          updated_query.value = deepClone(this.rule.default)
+        }
       }
 
       this.$emit('update:query', updated_query);


### PR DESCRIPTION
This fixes 2 edge-cases with custom components and their default value:

 * If default is falsy (i.e. `''`, `0` or `0.0`) it's replaced with `null`,
   which may break the custom-component or or violates its prop validation.
 * If default is non-primitive, a newly created rule of the same ID would
   receive a mutated, default value form the previous rule.